### PR TITLE
Fix/Observers should work when useRef object is passed

### DIFF
--- a/packages/react/src/hooks/useIntersectionObserver/useIntersectionObserver.test.tsx
+++ b/packages/react/src/hooks/useIntersectionObserver/useIntersectionObserver.test.tsx
@@ -1,4 +1,4 @@
-import { renderHook } from '@testing-library/react'
+import { render, renderHook } from '@testing-library/react'
 import { useRef } from 'react'
 
 import { useIntersectionObserver } from './useIntersectionObserver'
@@ -369,5 +369,21 @@ describe('useIntersectionObserver', () => {
         expect(observeSpy).toHaveBeenCalledWith(div)
         expect(IntersectionObserverSpy).toHaveBeenCalledTimes(1)
         expect(result.current).toBeUndefined()
+    })
+
+    it('should create IntersectionObserver instance when useRef object is passed', () => {
+        const callbackSpy = jest.fn()
+
+        const Component = () => {
+            const reference = useRef<HTMLDivElement>(null)
+            useIntersectionObserver(reference, callbackSpy)
+
+            return <div ref={reference}>Test</div>
+        }
+
+        render(<Component />)
+
+        expect(observeSpy).toHaveBeenCalledTimes(1)
+        expect(IntersectionObserverSpy).toHaveBeenCalledTimes(1)
     })
 })

--- a/packages/react/src/hooks/useIntersectionObserver/useIntersectionObserver.ts
+++ b/packages/react/src/hooks/useIntersectionObserver/useIntersectionObserver.ts
@@ -7,6 +7,10 @@ type TObserverPoolItem = { observer: IntersectionObserver; callbacks: Set<Inters
 // https://github.com/kickassCoderz/kickass-toolkit/pull/42#issuecomment-1169928398
 const observerPool: TObserverPoolItem[] = []
 
+const getTargetElement = <T extends Element>(target: React.RefObject<T> | T | null): T | null => {
+    return target && 'current' in target ? target.current : target
+}
+
 /**
  * Drop in hook replacement for IntersectionObserver
  * @beta - this hook is still in development and may change in the future
@@ -19,10 +23,11 @@ function useIntersectionObserver<T extends Element>(
     callbackFunction: IntersectionObserverCallback,
     options?: IntersectionObserverInit
 ): void {
-    const element = target && 'current' in target ? target.current : target
     // eslint-disable-next-line unicorn/no-null
     const { root = null, rootMargin = '0px 0px 0px 0px', threshold = 0 } = options || {}
     const observerCallback = useEffectEvent<IntersectionObserverCallback>((entries, observer) => {
+        const element = getTargetElement(target)
+
         const targetEntries = entries.filter(entry => entry.target === element)
 
         if (targetEntries.length > 0) {
@@ -80,6 +85,8 @@ function useIntersectionObserver<T extends Element>(
     }, [root, rootMargin, threshold, observerCallback])
 
     useEffect(() => {
+        const element = getTargetElement(target)
+
         if (!element || !observerItemReference.current?.observer) {
             return
         }
@@ -91,7 +98,7 @@ function useIntersectionObserver<T extends Element>(
         return () => {
             observerItem.unobserve(element)
         }
-    }, [element])
+    }, [target])
 }
 
 export { useIntersectionObserver }

--- a/packages/react/src/hooks/useResizeObserver/useResizeOberver.ts
+++ b/packages/react/src/hooks/useResizeObserver/useResizeOberver.ts
@@ -87,10 +87,11 @@ function useResizeObserver<T extends Element>(
     callbackFunction: ResizeObserverCallback
 ) {
     const resizeObserver = getResizeObserverInstance()
-    const targetElement = target && 'current' in target ? target.current : target
     const onResizeCallback = useEffectEvent(callbackFunction)
 
     useEffect(() => {
+        const targetElement = target && 'current' in target ? target.current : target
+
         if (resizeObserver && targetElement) {
             resizeObserver.subscribe(targetElement, onResizeCallback)
         }
@@ -100,7 +101,7 @@ function useResizeObserver<T extends Element>(
                 resizeObserver.unsubscribe(targetElement, onResizeCallback)
             }
         }
-    }, [resizeObserver, onResizeCallback, targetElement])
+    }, [resizeObserver, onResizeCallback, target])
 }
 
 export { useResizeObserver }


### PR DESCRIPTION
Real issue here was that we were never actually testing with real `useRef`. Since render never happens `ref.current` is always `undefined` during that first render, it only gets available in first effect phase (`useEffect`).

State worked because it is reactive and it would always re-render and thus trigger our `useEffect` and register observer. Same if you had any re-renders in the component in which you used observer.

`useResizeObserver` worked because of the different registration but I moved the logic inside `useEffect` still for consistency.

Closes #101
Closes #102 